### PR TITLE
add test scaffolding and simple tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ npm-debug.log
 # Generated
 client/
 log/
+coverage/

--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,10 @@ machine:
   node:
     version: 4.1.0
 
+test:
+  post:
+    - cp -r coverage $CIRCLE_ARTIFACTS/
+
 deployment:
   release:
     branch:

--- a/karma.conf.coverage.js
+++ b/karma.conf.coverage.js
@@ -1,0 +1,33 @@
+var istanbul = require('browserify-istanbul');
+
+module.exports = function (config) {
+    config.set({
+        basePath: 'source',
+        frameworks: ['browserify', 'mocha', 'chai-sinon'],
+        files: [
+            'js/**/*.spec.js'
+        ],
+        exclude: [],
+        preprocessors: {
+            'js/**/*.spec.js': ['browserify']
+        },
+        browserify: {
+            debug: true,
+            extensions: ["js", "hbs"],
+            transform: [['hbsfy', {"extensions": "hbs"}], istanbul({
+                ignore: ['**/node_modules/**', '**/*.spec.js']
+            })]
+        },
+        coverageReporter: {
+            type: 'lcov',
+            dir: '../coverage'
+        },
+        reporters: ['dots', 'coverage'],
+        port: 9876,
+        colors: true,
+        logLevel: config.LOG_INFO,
+        autoWatch: false,
+        browsers: ['Chrome'],
+        singleRun: true
+    });
+};

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,24 @@
+module.exports = function (config) {
+    config.set({
+        basePath: 'source',
+        frameworks: ['browserify', 'mocha', 'chai-sinon'],
+        files: [
+            'js/**/*.spec.js'
+        ],
+        exclude: [],
+        preprocessors: {
+            'js/**/*.spec.js': ['browserify']
+        },
+        browserify: {
+            debug: true,
+            extensions: ["js", "hbs"],
+            transform: [['hbsfy', {"extensions": "hbs"}]]
+        },
+        reporters: ['dots'],
+        port: 9876,
+        colors: true,
+        logLevel: config.LOG_INFO,
+        autoWatch: true,
+        browsers: ['PhantomJS2'],
+    });
+};

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build-js": "mkdir -p client/js && ./node_modules/.bin/browserify source/js/client.js -o client/js/client.js -t hbsfy",
     "build-less": "mkdir -p client/css && ./node_modules/.bin/lessc source/less/main.less client/css/main.css",
     "copy-fontawesome": "mkdir -p client/css && cp ./node_modules/font-awesome/css/font-awesome.min.css ./client/css/font-awesome.min.css && cp -R ./node_modules/font-awesome/fonts/ ./client/fonts/",
-    "test": "echo \"No test specified\""
+    "test": "./node_modules/.bin/karma start karma.conf.coverage.js"
   },
   "repository": {
     "type": "git",
@@ -33,6 +33,8 @@
   },
   "devDependencies": {
     "browser-sync": "^2.9.12",
+    "browserify-istanbul": "0.2.1",
+    "chai": "3.4.0",
     "del": "^2.0.2",
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^3.1.0",
@@ -41,8 +43,18 @@
     "gulp-less": "^3.0.3",
     "gulp-nodemon": "^2.0.4",
     "gulp-plumber": "^1.0.1",
+    "karma": "0.13.15",
+    "karma-browserify": "4.4.0",
+    "karma-chai-sinon": "0.1.5",
+    "karma-chrome-launcher": "0.2.1",
+    "karma-coverage": "0.5.3",
+    "karma-mocha": "0.2.0",
+    "karma-phantomjs2-launcher": "0.3.2",
+    "mocha": "2.3.3",
     "run-sequence": "^1.1.4",
     "signaling-server": "git://github.com/dunlin/signaling-server.git",
+    "sinon": "1.17.2",
+    "sinon-chai": "2.8.0",
     "supervisor": "^0.6.0",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^2.4.0"

--- a/source/js/avatar.spec.js
+++ b/source/js/avatar.spec.js
@@ -1,0 +1,35 @@
+describe('Avatar video', function () {
+    var $ = require('jquery'),
+        avatarFactory = require('./avatar.js');
+    var avatar, webrtc, node;
+
+    beforeEach(function () {
+        webrtc = {
+            mute: sinon.spy(),
+            unmute: sinon.spy()
+        };
+
+        node = $('<div></div>');
+
+        avatar = avatarFactory(node, webrtc);
+    });
+
+    it('should initialize correctly', function () {
+        expect(avatar.muted).to.be.false;
+        expect(avatar.node).to.equal(node);
+    });
+
+    it('should toggle the mute status on a click', function () {
+        node.trigger('click');
+
+        expect(avatar.muted).to.be.true;
+        expect(node.hasClass('muted')).to.be.true
+        expect(webrtc.mute).to.have.been.called;
+
+        node.trigger('click');
+
+        expect(avatar.muted).to.be.false;
+        expect(node.hasClass('muted')).to.be.false;
+        expect(webrtc.unmute).to.have.been.called;
+    });
+});

--- a/source/js/idle.js
+++ b/source/js/idle.js
@@ -1,27 +1,27 @@
 var $ = require('jquery'),
-	idle = function($target) {
-		return function() {
-			$target.addClass('idle');
-			$target.data('timer', undefined);
-		};
-	},
-	activity = function($target) {
-		return function() {
-			var timer = $target.data('timer');
-			
-			$target.removeClass('idle');
+    idle = function ($target) {
+        return function () {
+            $target.addClass('idle');
+            $target.data('timer', undefined);
+        };
+    },
+    activity = function ($target) {
+        return function () {
+            var timer = $target.data('timer');
 
-			if(timer) {
-				clearTimeout(timer);
-			}
+            $target.removeClass('idle');
 
-			$target.data('timer', setTimeout(idle($target), 2000));
-		}
-	};
+            if (timer) {
+                clearTimeout(timer);
+            }
 
-module.exports = function(target) {
-	var $target = $(target);
+            $target.data('timer', setTimeout(idle($target), 2000));
+        }
+    };
 
-	$(target).on('mousemove', activity($target));
-	$(target).on('click', activity($target));
+module.exports = function (target) {
+    var $target = $(target), cb = activity($target);
+
+    $target.on('mousemove', cb).on('click', cb);
+    cb();
 };

--- a/source/js/idle.spec.js
+++ b/source/js/idle.spec.js
@@ -1,0 +1,57 @@
+describe('Idle logic', function () {
+    var $ = require('jquery'),
+        idleFactory = require('./idle.js');
+
+    var inactivityTimeout = 2100,
+        target, clock;
+
+    beforeEach(function () {
+        clock = sinon.useFakeTimers();
+        target = $('<div></div>');
+        idleFactory(target);
+    });
+
+    afterEach(function () {
+        clock.restore();
+    });
+
+    it('should enter idle mode after a time of inactivity', function () {
+        clock.tick(inactivityTimeout);
+
+        expect(target.hasClass('idle')).to.be.true;
+    });
+
+    it('should exit idle mode after mouse activity', function () {
+        clock.tick(inactivityTimeout);
+
+        expect(target.hasClass('idle')).to.be.true;
+
+        target.trigger('mousemove');
+
+        expect(target.hasClass('idle')).to.be.false;
+    });
+
+    it('should exit idle mode after a click', function () {
+        clock.tick(inactivityTimeout);
+
+        expect(target.hasClass('idle')).to.be.true;
+
+        target.trigger('click');
+
+        expect(target.hasClass('idle')).to.be.false;
+    });
+
+    it('should reenter idle after inactivity', function () {
+        clock.tick(inactivityTimeout);
+
+        expect(target.hasClass('idle')).to.be.true;
+
+        target.trigger('click');
+
+        expect(target.hasClass('idle')).to.be.false;
+
+        clock.tick(inactivityTimeout);
+
+        expect(target.hasClass('idle')).to.be.true;
+    });
+});


### PR DESCRIPTION
Test framework for dunlin. CI uses karma.conf.coverage.js and adds coverage report to build artifacts. karma.conf.js can be used during development and uses watchers to trigger the browserify recompile (`./node_modules/.bin/karma start karma.conf.js`).

If #31 is merged first, the orientation test is becoming obsolete.

@alexander-heimbuch please review.

BTW: locally PhantomJS2 is used, CI uses Chrome because it does not yet work with PhantomJS2.
